### PR TITLE
Update the Adafruit GFX lib name

### DIFF
--- a/SSD1331/library.json
+++ b/SSD1331/library.json
@@ -9,7 +9,7 @@
   },
   "dependencies":
   {
-    "name": "Adafruit-GFX",
+    "name": "Adafruit GFX Library",
     "frameworks": "arduino"
   },
   "frameworks": "arduino",


### PR DESCRIPTION
Looks like the name of the Adafruit GFX library that this one depends on changed in platformio. So updating to match.